### PR TITLE
From Single Crystal to Powder Mode Switch

### DIFF
--- a/src/hyspecppt/hppt/experiment_settings.py
+++ b/src/hyspecppt/hppt/experiment_settings.py
@@ -18,6 +18,7 @@ PLOT_TYPES = [
 DEFAULT_LATTICE = dict(a=1, b=1, c=1, alpha=90, beta=90, gamma=90, h=0, k=0, l=0)
 DEFAULT_EXPERIMENT = dict(Ei=20, S2=30, alpha_p=0, plot_type=PLOT_TYPES[1])
 DEFAULT_CROSSHAIR = dict(DeltaE=0, modQ=0)
+DEFAULT_MODE = dict(current_experiment_type="single_crystal")
 
 # invalid style
 INVALID_QLINEEDIT = """

--- a/src/hyspecppt/hppt/hppt_model.py
+++ b/src/hyspecppt/hppt/hppt_model.py
@@ -153,6 +153,15 @@ class HyspecPPTModel:
         self.alpha_p = alpha_p
         self.plot_type = plot_type
 
+    def get_experiment_data(self) -> dict[str, float]:
+        data = dict()
+
+        data["Ei"] = self.Ei
+        data["S2"] = self.S2
+        data["alpha_p"] = self.alpha_p
+        data["plot_type"] = self.plot_type
+        return data
+
     def get_graph_data(self) -> list[float, float, float, list, list, list]:
         return self.calculate_graph_data()
 

--- a/src/hyspecppt/hppt/hppt_presenter.py
+++ b/src/hyspecppt/hppt/hppt_presenter.py
@@ -27,8 +27,11 @@ class HyspecPPTPresenter:
         # model init
         # to be removed needs to happen in the model
         self.model.set_experiment_data(**DEFAULT_EXPERIMENT)
+        print("DEFAULT_CROSSHAIR", DEFAULT_CROSSHAIR, DEFAULT_MODE)
         self.model.set_crosshair_data(**DEFAULT_CROSSHAIR, **DEFAULT_MODE)
         self.model.set_single_crystal_data(params=DEFAULT_LATTICE)
+
+        self.view.SelW.selector_init()  # pass the default mode from experiment type
 
     @property
     def view(self):
@@ -51,7 +54,9 @@ class HyspecPPTPresenter:
             if experiment_type_label.startswith("Single"):
                 experiment_type = "single_crystal"
             print("data", data, experiment_type)
-            self.model.set_crosshair_data(experiment_type, float(data["DeltaE"]), float(data["modQ"]))
+            self.model.set_crosshair_data(
+                current_experiment_type=experiment_type, DeltaE=float(data["DeltaE"]), modQ=float(data["modQ"])
+            )
         elif section == "experiment":
             self.model.set_experiment_data(
                 float(data["Ei"]), float(data["S2"]), float(data["alpha_p"]), data["plot_type"]
@@ -64,6 +69,9 @@ class HyspecPPTPresenter:
         """Switch to Powder mode"""
         # update the fields' visibility
         self.view.field_visibility_in_Powder()
+        # update the experiment type in the model
+        experiment_type = "powder"
+        self.model.set_crosshair_data(current_experiment_type=experiment_type)
 
         # get the valid values for crosshair saved fields
         # if the view contains an invalid value it is overwritten
@@ -76,12 +84,15 @@ class HyspecPPTPresenter:
         """Switch to Single Crystal mode"""
         # update the fields' visibility
         self.view.field_visibility_in_SC()
+        # update the experiment type in the model
+        experiment_type = "single_crystal"
+        self.model.set_crosshair_data(current_experiment_type=experiment_type)
 
         # get the valid values for crosshair saved fields
         # if the view contains an invalid value it is overwritten
         saved_values = self.model.get_crosshair_data()
+        print("sc saved", saved_values)
         self.view.CW.set_values(saved_values)
-        print("saved", saved_values)
         print("view updated with: ", saved_values)
 
         # get the valid values for lattice saved fields

--- a/src/hyspecppt/hppt/hppt_presenter.py
+++ b/src/hyspecppt/hppt/hppt_presenter.py
@@ -19,7 +19,6 @@ class HyspecPPTPresenter:
         self.view.EW.initializeCombo(PLOT_TYPES)
         self.view.EW.set_values(DEFAULT_EXPERIMENT)
         self.view.CW.set_values(DEFAULT_CROSSHAIR)
-        self.view.SelW.set_SC_toggle(True)
 
         self.get_Experiment_values()
         self.get_SingleCrystal_values()

--- a/src/hyspecppt/hppt/hppt_presenter.py
+++ b/src/hyspecppt/hppt/hppt_presenter.py
@@ -80,6 +80,9 @@ class HyspecPPTPresenter:
         saved_values = self.model.get_crosshair_data()
         self.view.CW.set_values(saved_values)
 
+        saved_values = self.model.get_experiment_data()
+        self.view.EW.set_values(saved_values)
+
     def handle_switch_to_sc(self):
         """Switch to Single Crystal mode"""
         # update the fields' visibility

--- a/src/hyspecppt/hppt/hppt_presenter.py
+++ b/src/hyspecppt/hppt/hppt_presenter.py
@@ -1,6 +1,6 @@
 """Presenter for the Main tab"""
 
-from .experiment_settings import DEFAULT_CROSSHAIR, DEFAULT_EXPERIMENT, DEFAULT_LATTICE, PLOT_TYPES
+from .experiment_settings import DEFAULT_CROSSHAIR, DEFAULT_EXPERIMENT, DEFAULT_LATTICE, DEFAULT_MODE, PLOT_TYPES
 
 
 class HyspecPPTPresenter:
@@ -17,17 +17,18 @@ class HyspecPPTPresenter:
         # M-V-P connections through callbacks
         self.view.connect_fields_update(self.handle_field_values_update)
         self.view.connect_powder_mode_switch(self.handle_switch_to_powder)
+        self.view.connect_sc_mode_switch(self.handle_switch_to_sc)
 
         self.view.SCW.set_values(DEFAULT_LATTICE)
         self.view.EW.initializeCombo(PLOT_TYPES)
         self.view.EW.set_values(DEFAULT_EXPERIMENT)
         self.view.CW.set_values(DEFAULT_CROSSHAIR)
 
-        # to be removed
-        self.get_Experiment_values()
-        self.get_SingleCrystal_values()
-        self.get_Selector_values()
-        self.get_Crosshair_values()
+        # model init
+        # to be removed needs to happen in the model
+        self.model.set_experiment_data(**DEFAULT_EXPERIMENT)
+        self.model.set_crosshair_data(**DEFAULT_CROSSHAIR, **DEFAULT_MODE)
+        self.model.set_single_crystal_data(params=DEFAULT_LATTICE)
 
     @property
     def view(self):
@@ -39,79 +40,50 @@ class HyspecPPTPresenter:
         """Return the model for this presenter"""
         return self._model
 
-    def get_Experiment_values(self) -> dict:
-        """Get Ei, Pangle, S2, Type values from Experiment
-
-        return: dict of Experiment key value pairs
-        """
-        EW_dict = {}
-        EW_dict["Ei"] = self.view.EW.Ei_edit.text()
-        EW_dict["Pangle"] = self.view.EW.Pangle_edit.text()
-        EW_dict["S2"] = self.view.EW.S2_edit.text()
-        EW_dict["Type"] = self.view.EW.Type_combobox.currentText()
-        return EW_dict
-
-    def get_Selector_values(self):
-        """Check if Single Crystal radio button is checked
-
-        return: True - Single Crystal radio button is toggled
-                False - Single Crystal radio button is not toggled. Powder radio button is toggled
-        """
-        return self.view.SelW.sc_rb.isChecked()
-
-    def get_SingleCrystal_values(self):
-        """Get Single Crystal mode specific values from SingleCrystalWidget
-
-        return: dict of Single Crystal key value pairs
-        """
-        SC_dict = {}
-        SC_dict["a"] = self.view.SCW.a_edit.text()
-        SC_dict["b"] = self.view.SCW.b_edit.text()
-        SC_dict["c"] = self.view.SCW.c_edit.text()
-
-        SC_dict["alpha"] = self.view.SCW.alpha_edit.text()
-        SC_dict["beta"] = self.view.SCW.beta_edit.text()
-        SC_dict["gamma"] = self.view.SCW.gamma_edit.text()
-
-        SC_dict["h"] = self.view.SCW.h_edit.text()
-        SC_dict["k"] = self.view.SCW.k_edit.text()
-        SC_dict["l"] = self.view.SCW.l_edit.text()
-        return SC_dict
-
-    def get_Crosshair_values(self):
-        """Get Crosshair mode specific values from CrosshairWidget
-
-        return: dict of Crosshair key value pairs
-        """
-        CH_dict = {}
-        CH_dict["DeltaE"] = self.view.CW.DeltaE_edit.text()
-        CH_dict["modQ"] = self.view.CW.modQ_edit.text()
-        return CH_dict
-
-    def set_PlotWidget_values(self):
-        """Pass through intensity matrix into plot in view"""
-        pass
-
     def handle_field_values_update(self, field_values):
         """Save the values in the model"""
         section = field_values["name"]
         data = field_values["data"]
         if section == "crosshair":
-            self.model.save_crosshair_data(data)
+            # get the current experiment type
+            experiment_type_label = self.view.SelW.get_selected_mode_label()
+            experiment_type = "powder"
+            if experiment_type_label.startswith("Single"):
+                experiment_type = "single_crystal"
+            print("data", data, experiment_type)
+            self.model.set_crosshair_data(experiment_type, float(data["DeltaE"]), float(data["modQ"]))
         elif section == "experiment":
-            self.model.save_experiment_data(
+            self.model.set_experiment_data(
                 float(data["Ei"]), float(data["S2"]), float(data["alpha_p"]), data["plot_type"]
             )
         else:
-            self.model.save_sc_data(data)
+            print("dsad", data)
+            self.model.set_single_crystal_data(data)
 
     def handle_switch_to_powder(self):
         """Switch to Powder mode"""
         # update the fields' visibility
         self.view.field_visibility_in_Powder()
 
-        # get the valid values for all saved fields
+        # get the valid values for crosshair saved fields
         # if the view contains an invalid value it is overwritten
-        saved_values = self.model.get_experiment_data()
-        self.view.EW.set_values(saved_values)
+        saved_values = self.model.get_crosshair_data()
+        print("saved", saved_values)
+        self.view.CW.set_values(saved_values)
         print("view updated with: ", saved_values)
+
+    def handle_switch_to_sc(self):
+        """Switch to Single Crystal mode"""
+        # update the fields' visibility
+        self.view.field_visibility_in_SC()
+
+        # get the valid values for crosshair saved fields
+        # if the view contains an invalid value it is overwritten
+        saved_values = self.model.get_crosshair_data()
+        self.view.CW.set_values(saved_values)
+        print("saved", saved_values)
+        print("view updated with: ", saved_values)
+
+        # get the valid values for lattice saved fields
+        # saved_values = self.model.get_single_crystal_data()
+        # self.view.CW.set_values(saved_values)

--- a/src/hyspecppt/hppt/hppt_presenter.py
+++ b/src/hyspecppt/hppt/hppt_presenter.py
@@ -19,6 +19,7 @@ class HyspecPPTPresenter:
         self.view.connect_powder_mode_switch(self.handle_switch_to_powder)
         self.view.connect_sc_mode_switch(self.handle_switch_to_sc)
 
+        # populate fields
         self.view.SCW.set_values(DEFAULT_LATTICE)
         self.view.EW.initializeCombo(PLOT_TYPES)
         self.view.EW.set_values(DEFAULT_EXPERIMENT)
@@ -27,11 +28,14 @@ class HyspecPPTPresenter:
         # model init
         # to be removed needs to happen in the model
         self.model.set_experiment_data(**DEFAULT_EXPERIMENT)
-        print("DEFAULT_CROSSHAIR", DEFAULT_CROSSHAIR, DEFAULT_MODE)
         self.model.set_crosshair_data(**DEFAULT_CROSSHAIR, **DEFAULT_MODE)
         self.model.set_single_crystal_data(params=DEFAULT_LATTICE)
 
-        self.view.SelW.selector_init()  # pass the default mode from experiment type
+        # set default selection mode
+        experiment_type = self.view.SelW.powder_label
+        if DEFAULT_MODE["current_experiment_type"].startswith("single"):
+            experiment_type = self.view.SelW.sc_label
+        self.view.SelW.selector_init(experiment_type)  # pass the default mode from experiment type
 
     @property
     def view(self):
@@ -53,7 +57,6 @@ class HyspecPPTPresenter:
             experiment_type = "powder"
             if experiment_type_label.startswith("Single"):
                 experiment_type = "single_crystal"
-            print("data", data, experiment_type)
             self.model.set_crosshair_data(
                 current_experiment_type=experiment_type, DeltaE=float(data["DeltaE"]), modQ=float(data["modQ"])
             )
@@ -62,7 +65,6 @@ class HyspecPPTPresenter:
                 float(data["Ei"]), float(data["S2"]), float(data["alpha_p"]), data["plot_type"]
             )
         else:
-            print("dsad", data)
             self.model.set_single_crystal_data(data)
 
     def handle_switch_to_powder(self):
@@ -76,9 +78,7 @@ class HyspecPPTPresenter:
         # get the valid values for crosshair saved fields
         # if the view contains an invalid value it is overwritten
         saved_values = self.model.get_crosshair_data()
-        print("saved", saved_values)
         self.view.CW.set_values(saved_values)
-        print("view updated with: ", saved_values)
 
     def handle_switch_to_sc(self):
         """Switch to Single Crystal mode"""
@@ -91,9 +91,7 @@ class HyspecPPTPresenter:
         # get the valid values for crosshair saved fields
         # if the view contains an invalid value it is overwritten
         saved_values = self.model.get_crosshair_data()
-        print("sc saved", saved_values)
         self.view.CW.set_values(saved_values)
-        print("view updated with: ", saved_values)
 
         # get the valid values for lattice saved fields
         # saved_values = self.model.get_single_crystal_data()

--- a/src/hyspecppt/hppt/hppt_presenter.py
+++ b/src/hyspecppt/hppt/hppt_presenter.py
@@ -15,11 +15,16 @@ class HyspecPPTPresenter:
         """
         self._view = view
         self._model = model
+
+        # M-V-P connections through callbacks
+        self.view.connect_ei_update(self.handle_ei_update)
+
         self.view.SCW.set_values(DEFAULT_LATTICE)
         self.view.EW.initializeCombo(PLOT_TYPES)
         self.view.EW.set_values(DEFAULT_EXPERIMENT)
         self.view.CW.set_values(DEFAULT_CROSSHAIR)
 
+        # to be removed
         self.get_Experiment_values()
         self.get_SingleCrystal_values()
         self.get_Selector_values()
@@ -87,3 +92,7 @@ class HyspecPPTPresenter:
     def set_PlotWidget_values(self):
         """Pass through intensity matrix into plot in view"""
         pass
+
+    def handle_ei_update(self, ei_value):
+        """Save the Ei value"""
+        self.model.save_Ei(ei_value)

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -163,18 +163,11 @@ class SelectorWidget(QWidget):
         """Update fields based on selected mode
         Args:
         """
-        if self.powder_rb.isChecked():
-            self.parent().switch_to_Powder()
-        else:
-            self.parent().switch_to_SC()
-
-    def set_SC_toggle(self, toggle: bool) -> None:
-        """Sets widget display based on the values dictionary
-        Args:
-            toggle: True - Single Crystal radio button is toggled
-            toggle: False - Single Crystal radio button is not toggled
-        """
-        self.sc_rb.setChecked(toggle)
+        if self.parent():
+            if self.powder_rb.isChecked():
+                self.parent().switch_to_Powder()
+            else:
+                self.parent().switch_to_SC()
 
 
 class SingleCrystalWidget(QWidget):

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -153,8 +153,9 @@ class SelectorWidget(QWidget):
         selector_layout.addWidget(self.sc_rb)
         self.setLayout(selector_layout)
 
-        self.powder_rb.toggled.connect(self.sc_toggle)
-        self.sc_rb.toggled.connect(self.sc_toggle)
+        if parent:
+            self.powder_rb.toggled.connect(self.sc_toggle)
+            self.sc_rb.toggled.connect(self.sc_toggle)
 
         # default mode is SC
         self.sc_rb.setChecked(True)
@@ -163,11 +164,10 @@ class SelectorWidget(QWidget):
         """Update fields based on selected mode
         Args:
         """
-        if self.parent():
-            if self.powder_rb.isChecked():
-                self.parent().switch_to_Powder()
-            else:
-                self.parent().switch_to_SC()
+        if self.powder_rb.isChecked():
+            self.parent().switch_to_Powder()
+        else:
+            self.parent().switch_to_SC()
 
 
 class SingleCrystalWidget(QWidget):

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -89,18 +89,16 @@ class HyspecPPTView(QWidget):
         layout.addLayout(layoutLeft)
         self.EW = ExperimentWidget(self)
         layoutLeft.addWidget(self.EW)
+        self.SCW = SingleCrystalWidget(self)
+        self.CW = CrosshairWidget(self)
         self.SelW = SelectorWidget(self)
         layoutLeft.addWidget(self.SelW)
-        self.SCW = SingleCrystalWidget(self)
         layoutLeft.addWidget(self.SCW)
-        self.CW = CrosshairWidget(self)
         layoutLeft.addWidget(self.CW)
         spacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
         layoutLeft.addItem(spacer)
         self.PW = PlotWidget(self)
         layout.addWidget(self.PW)
-
-        self.switch_to_SC()
 
     def switch_to_SC(self) -> None:
         """Set visibility for Single Crystal mode"""
@@ -154,6 +152,21 @@ class SelectorWidget(QWidget):
         selector_layout.addWidget(self.powder_rb)
         selector_layout.addWidget(self.sc_rb)
         self.setLayout(selector_layout)
+
+        self.powder_rb.toggled.connect(self.sc_toggle)
+        self.sc_rb.toggled.connect(self.sc_toggle)
+
+        # default mode is SC
+        self.sc_rb.setChecked(True)
+
+    def sc_toggle(self) -> None:
+        """Update fields based on selected mode
+        Args:
+        """
+        if self.powder_rb.isChecked():
+            self.parent().switch_to_Powder()
+        else:
+            self.parent().switch_to_SC()
 
     def set_SC_toggle(self, toggle: bool) -> None:
         """Sets widget display based on the values dictionary

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -99,6 +99,7 @@ class HyspecPPTView(QWidget):
         """Set visibility for Single Crystal mode"""
         self.SCW.setVisible(True)
         self.CW.set_Qmod_enabled(False)
+        print("Visibility trace")
 
     def field_visibility_in_Powder(self) -> None:
         """Set visibility for Powder mode"""
@@ -154,6 +155,10 @@ class SelectorWidget(QWidget):
             self.powder_rb.toggled.connect(self.sc_toggle)
             self.sc_rb.toggled.connect(self.sc_toggle)
 
+    def selector_init(self):
+        """Initialize the default selected mode
+        Args:
+        """
         # default mode is SC
         self.sc_rb.setChecked(True)
 

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -82,6 +82,8 @@ class HyspecPPTView(QWidget):
 
         """
         super().__init__(parent)
+        # callback functions
+        self.ei_callback = None
 
         layout = QHBoxLayout()
         self.setLayout(layout)
@@ -99,6 +101,14 @@ class HyspecPPTView(QWidget):
         layoutLeft.addItem(spacer)
         self.PW = PlotWidget(self)
         layout.addWidget(self.PW)
+
+    def connect_ei_update(self, callback):
+        """Callback for the Ei field update"""
+        self.ei_callback = callback
+
+    def values_update(self, value):
+        """Ei field update"""
+        self.ei_callback(value)
 
     def switch_to_SC(self) -> None:
         """Set visibility for Single Crystal mode"""
@@ -423,7 +433,11 @@ class ExperimentWidget(QWidget):
             if edit.hasAcceptableInput():
                 out_signal[k] = float(edit.text())
         if len(out_signal) == 4:
+            # to be removed
             self.valid_signal.emit(out_signal)
+            # send the values
+            if self.parent():
+                self.parent().values_update(self.Ei_edit.text())
 
     def set_values(self, values: dict[str, Union[float, str]]) -> None:
         """Sets widget display based on the values dictionary

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -99,7 +99,6 @@ class HyspecPPTView(QWidget):
         """Set visibility for Single Crystal mode"""
         self.SCW.setVisible(True)
         self.CW.set_Qmod_enabled(False)
-        print("Visibility trace")
 
     def field_visibility_in_Powder(self) -> None:
         """Set visibility for Powder mode"""
@@ -155,12 +154,16 @@ class SelectorWidget(QWidget):
             self.powder_rb.toggled.connect(self.sc_toggle)
             self.sc_rb.toggled.connect(self.sc_toggle)
 
-    def selector_init(self):
+    def selector_init(self, selected_label: str):
         """Initialize the default selected mode
         Args:
+            selected_label: it contains either sc_label or powder_label
+            based on the selected label the mode is set during initialization
         """
-        # default mode is SC
-        self.sc_rb.setChecked(True)
+        if selected_label == self.sc_label:
+            self.sc_rb.setChecked(True)
+        else:
+            self.powder_rb.setChecked(True)
 
     def sc_toggle(self) -> None:
         """Update fields based on selected mode

--- a/src/hyspecppt/hppt/hppt_view_validators.py
+++ b/src/hyspecppt/hppt/hppt_view_validators.py
@@ -1,0 +1,50 @@
+import copy
+from typing import Optional
+
+import numpy as np
+from qtpy.QtCore import QObject
+from qtpy.QtGui import QDoubleValidator, QValidator
+
+
+class AbsValidator(QDoubleValidator):
+    """Absolute value validator"""
+
+    def __init__(
+        self, parent: Optional["QObject"] = None, bottom: float = 0, top: float = np.inf, decimals: int = -1
+    ) -> None:
+        """Constructor for the absolute value validator. All the parameters
+           are the same as for QDoubleValidator, but the valid value is between a
+           positive bottom and top, or between -top and -bottom
+
+        Args:
+            parent (QObject): Optional parent
+            bottom (float): the minimum positive value (set to 0 if not positive)
+            top (float): the highest top value (set to infinity if not greater than bottom)
+            decimals (int): the number of digits after the decimal point.
+
+        """
+        if bottom < 0:
+            bottom = 0
+        if top <= bottom:
+            top = np.inf
+        super().__init__(parent=parent, bottom=bottom, top=top, decimals=decimals)
+
+    def validate(self, inp: str, pos: int) -> tuple[QValidator.State, str, int]:
+        """Override for validate method
+
+        Args:
+            inp (str): the input string
+            pos (int): cursor position
+
+        """
+        original_str = copy.copy(inp)
+        original_pos = pos
+        if inp == "-":
+            return QValidator.Intermediate
+        try:
+            inp = str(abs(float(inp)))
+        except ValueError:
+            pass
+        x = super().validate(inp, pos)
+        # do not "fix" the input
+        return x[0], original_str, original_pos

--- a/src/hyspecppt/hppt/hppt_view_validators.py
+++ b/src/hyspecppt/hppt/hppt_view_validators.py
@@ -1,7 +1,5 @@
 import copy
-from typing import Optional
 
-import numpy as np
 from qtpy.QtCore import QObject
 from qtpy.QtGui import QDoubleValidator, QValidator
 
@@ -9,9 +7,7 @@ from qtpy.QtGui import QDoubleValidator, QValidator
 class AbsValidator(QDoubleValidator):
     """Absolute value validator"""
 
-    def __init__(
-        self, parent: Optional["QObject"] = None, bottom: float = 0, top: float = np.inf, decimals: int = -1
-    ) -> None:
+    def __init__(self, parent: QObject, bottom: float, top: float, decimals: int = -1) -> None:
         """Constructor for the absolute value validator. All the parameters
            are the same as for QDoubleValidator, but the valid value is between a
            positive bottom and top, or between -top and -bottom
@@ -23,10 +19,6 @@ class AbsValidator(QDoubleValidator):
             decimals (int): the number of digits after the decimal point.
 
         """
-        if bottom < 0:
-            bottom = 0
-        if top <= bottom:
-            top = np.inf
         super().__init__(parent=parent, bottom=bottom, top=top, decimals=decimals)
 
     def validate(self, inp: str, pos: int) -> tuple[QValidator.State, str, int]:

--- a/tests/hppt_presenter/test_presenter.py
+++ b/tests/hppt_presenter/test_presenter.py
@@ -33,3 +33,23 @@ def test_Selector_widget_powder_mode(hyspec_app, qtbot):
 
     assert not hyspec_view.SCW.isVisibleTo(hyspec_app)
     assert hyspec_view.CW.modQ_edit.isEnabled()
+
+
+def test_switch_to_SC(hyspec_app, qtbot):
+    """Test switch_to_SC() set SingleCrystalWidget visible"""
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    hyspec_view.switch_to_SC()
+    assert hyspec_view.SCW.isVisibleTo(hyspec_view)
+    assert not hyspec_view.CW.modQ_edit.isEnabled()
+
+
+def test_switch_to_Powder(hyspec_app, qtbot):
+    """Test switch_to_Powder() set SingleCrystalWidget visible"""
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    hyspec_view.switch_to_Powder()
+    assert not hyspec_view.SCW.isVisibleTo(hyspec_view)
+    assert hyspec_view.CW.modQ_edit.isEnabled()

--- a/tests/hppt_presenter/test_presenter.py
+++ b/tests/hppt_presenter/test_presenter.py
@@ -171,7 +171,7 @@ def test_switch_to_powder_qmod_default_value(hyspec_app, qtbot):
     hyspec_view.switch_to_powder()
 
     # Qmod value should be back to its default value
-    assert crosshair_widget.modQ_edit.text() == "0"
+    assert crosshair_widget.modQ_edit.text() == "0.0"
     assert crosshair_widget.modQ_edit.styleSheet() != INVALID_QLINEEDIT
 
 
@@ -218,8 +218,14 @@ def test_switch_to_powder_qmod_updated_values(hyspec_app, qtbot):
     hyspec_view = hyspec_app.main_window.HPPT_view
     crosshair_widget = hyspec_view.CW
 
+    assert crosshair_widget.modQ_edit.text() == "0.0"
+
+    # switch to powder
+    hyspec_view.switch_to_powder()
+
     # set a valid Qmod value
     crosshair_widget.modQ_edit.clear()
+    assert crosshair_widget.modQ_edit.text() == ""
 
     qtbot.keyClicks(crosshair_widget.modQ_edit, "2.35")
     assert crosshair_widget.modQ_edit.text() == "2.35"
@@ -228,14 +234,14 @@ def test_switch_to_powder_qmod_updated_values(hyspec_app, qtbot):
     crosshair_widget.modQ_edit.setFocus()
     qtbot.keyPress(crosshair_widget.modQ_edit, Qt.Key_Return)
 
-    # empty DeltaE value
+    # empty Qmod value
     crosshair_widget.modQ_edit.clear()
     assert crosshair_widget.modQ_edit.text() == ""
     assert crosshair_widget.modQ_edit.styleSheet() == INVALID_QLINEEDIT
 
     # switch to powder
-    hyspec_view.switch_to_powder()
+    hyspec_view.switch_to_SC()
 
     # Qmod value should be back to its default value
-    assert crosshair_widget.modQ_edit.text() == "2.35"
+    assert crosshair_widget.modQ_edit.text() == "0.0"
     assert crosshair_widget.modQ_edit.styleSheet() != INVALID_QLINEEDIT

--- a/tests/hppt_presenter/test_presenter.py
+++ b/tests/hppt_presenter/test_presenter.py
@@ -1,8 +1,8 @@
 import unittest
 from unittest.mock import Mock
 
-import hyspecppt.hppt.hppt_presenter as hppt_presenter
 from hyspecppt.hppt.experiment_settings import DEFAULT_CROSSHAIR, DEFAULT_EXPERIMENT, DEFAULT_LATTICE, PLOT_TYPES
+from hyspecppt.hppt.hppt_presenter import HyspecPPTPresenter
 
 
 class PresenterTests(unittest.TestCase):
@@ -10,7 +10,7 @@ class PresenterTests(unittest.TestCase):
         """Tests that presenter is initialized correctly"""
         mock_view = Mock()
         mock_model = Mock()
-        presenter = hppt_presenter.HyspecPPTPresenter(mock_view, mock_model)
+        presenter = HyspecPPTPresenter(mock_view, mock_model)
         mock_view.SCW.set_values.assert_called_once_with(DEFAULT_LATTICE)
         mock_view.EW.initializeCombo.assert_called_once_with(PLOT_TYPES)
         mock_view.EW.set_values.assert_called_once_with(DEFAULT_EXPERIMENT)
@@ -22,3 +22,14 @@ class PresenterTests(unittest.TestCase):
         mock_view.EW.Type_combobox.currentText.assert_called_once()
         assert presenter.view == mock_view
         assert presenter.model == mock_model
+
+
+def test_Selector_widget_powder_mode(hyspec_app, qtbot):
+    """Test the Powder Mode in Selector widget when the radio button is pressed"""
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    hyspec_view.SelW.powder_rb.setChecked(True)
+
+    assert not hyspec_view.SCW.isVisibleTo(hyspec_app)
+    assert hyspec_view.CW.modQ_edit.isEnabled()

--- a/tests/hppt_presenter/test_presenter.py
+++ b/tests/hppt_presenter/test_presenter.py
@@ -15,7 +15,6 @@ class PresenterTests(unittest.TestCase):
         mock_view.EW.initializeCombo.assert_called_once_with(PLOT_TYPES)
         mock_view.EW.set_values.assert_called_once_with(DEFAULT_EXPERIMENT)
         mock_view.CW.set_values.assert_called_once_with(DEFAULT_CROSSHAIR)
-        # mock_view.SelW.set_SC_toggle.assert_called_once_with(True)
         # maybe move these to a function in the view
         mock_view.EW.Ei_edit.text.assert_called_once()
         mock_view.EW.Pangle_edit.text.assert_called_once()

--- a/tests/hppt_presenter/test_presenter.py
+++ b/tests/hppt_presenter/test_presenter.py
@@ -15,7 +15,7 @@ class PresenterTests(unittest.TestCase):
         mock_view.EW.initializeCombo.assert_called_once_with(PLOT_TYPES)
         mock_view.EW.set_values.assert_called_once_with(DEFAULT_EXPERIMENT)
         mock_view.CW.set_values.assert_called_once_with(DEFAULT_CROSSHAIR)
-        mock_view.SelW.set_SC_toggle.assert_called_once_with(True)
+        # mock_view.SelW.set_SC_toggle.assert_called_once_with(True)
         # maybe move these to a function in the view
         mock_view.EW.Ei_edit.text.assert_called_once()
         mock_view.EW.Pangle_edit.text.assert_called_once()

--- a/tests/hppt_presenter/test_presenter.py
+++ b/tests/hppt_presenter/test_presenter.py
@@ -1,33 +1,31 @@
-import unittest
-from unittest.mock import Mock
+from PySide6.QtCore import Qt
 
-from hyspecppt.hppt.experiment_settings import DEFAULT_CROSSHAIR, DEFAULT_EXPERIMENT, DEFAULT_LATTICE, PLOT_TYPES
-from hyspecppt.hppt.hppt_presenter import HyspecPPTPresenter
+from hyspecppt.hppt.experiment_settings import INVALID_QLINEEDIT
 
 
-class PresenterTests(unittest.TestCase):
-    def test_presenter_init(self):
-        """Tests that presenter is initialized correctly"""
-        mock_view = Mock()
-        mock_model = Mock()
-        presenter = HyspecPPTPresenter(mock_view, mock_model)
-        mock_view.SCW.set_values.assert_called_once_with(DEFAULT_LATTICE)
-        mock_view.EW.initializeCombo.assert_called_once_with(PLOT_TYPES)
-        mock_view.EW.set_values.assert_called_once_with(DEFAULT_EXPERIMENT)
-        mock_view.CW.set_values.assert_called_once_with(DEFAULT_CROSSHAIR)
-        # maybe move these to a function in the view
-        mock_view.EW.Ei_edit.text.assert_called_once()
-        mock_view.EW.Pangle_edit.text.assert_called_once()
-        mock_view.EW.S2_edit.text.assert_called_once()
-        mock_view.EW.Type_combobox.currentText.assert_called_once()
-        assert presenter.view == mock_view
-        assert presenter.model == mock_model
-
-
-def test_Selector_widget_powder_mode(hyspec_app, qtbot):
-    """Test the Powder Mode in Selector widget when the radio button is pressed"""
+def test_presenter_init(qtbot, hyspec_app):
+    """Tests that presenter is initialized correctly"""
+    # show the app
     hyspec_app.show()
     qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    view = hyspec_app.main_window.HPPT_view
+
+    # check the default values are populated
+    assert view.EW.Ei_edit.text() == "20"
+    assert view.EW.Pangle_edit.text() == "0"
+    assert view.EW.S2_edit.text() == "30"
+    assert view.EW.Type_combobox.currentText() == "cos" + "\u03b1" + "\u209b" + "\u00b2"
+
+
+def test_selector_widget_powder_mode(hyspec_app, qtbot):
+    """Test the Powder Mode in Selector widget when the radio button is pressed"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
     hyspec_view = hyspec_app.main_window.HPPT_view
     hyspec_view.SelW.powder_rb.setChecked(True)
 
@@ -35,21 +33,209 @@ def test_Selector_widget_powder_mode(hyspec_app, qtbot):
     assert hyspec_view.CW.modQ_edit.isEnabled()
 
 
-def test_switch_to_SC(hyspec_app, qtbot):
+def test_switch_to_sc(hyspec_app, qtbot):
     """Test switch_to_SC() set SingleCrystalWidget visible"""
+    # show the app
     hyspec_app.show()
     qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
     hyspec_view = hyspec_app.main_window.HPPT_view
     hyspec_view.switch_to_SC()
     assert hyspec_view.SCW.isVisibleTo(hyspec_view)
     assert not hyspec_view.CW.modQ_edit.isEnabled()
 
 
-def test_switch_to_Powder(hyspec_app, qtbot):
-    """Test switch_to_Powder() set SingleCrystalWidget visible"""
+def test_switch_to_powder(hyspec_app, qtbot):
+    """Test switch_to_powder() set SingleCrystalWidget visible"""
+    # show the app
     hyspec_app.show()
     qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
     hyspec_view = hyspec_app.main_window.HPPT_view
-    hyspec_view.switch_to_Powder()
+    hyspec_view.switch_to_powder()
     assert not hyspec_view.SCW.isVisibleTo(hyspec_view)
     assert hyspec_view.CW.modQ_edit.isEnabled()
+
+
+def test_switch_to_powder_ei(hyspec_app, qtbot):
+    """Test switch to Powder check Ei value"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    experiment_widget = hyspec_view.EW
+
+    # set Ei invalid value
+    qtbot.keyClicks(experiment_widget.Ei_edit, "4")
+    assert experiment_widget.Ei_edit.text() == "204"
+    assert experiment_widget.Ei_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # switch to powder
+    hyspec_view.switch_to_powder()
+
+    # Ei value should be the same
+    assert experiment_widget.Ei_edit.text() == "204"
+    assert experiment_widget.Ei_edit.styleSheet() == INVALID_QLINEEDIT
+
+
+def test_switch_to_powder_pangle(hyspec_app, qtbot):
+    """Test switch to Powder check P angle value"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    experiment_widget = hyspec_view.EW
+
+    # empty p angle value
+    experiment_widget.Pangle_edit.clear()
+    assert experiment_widget.Pangle_edit.text() == ""
+    assert experiment_widget.Pangle_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # switch to powder
+    hyspec_view.switch_to_powder()
+
+    # P angle value should be the same
+    assert experiment_widget.Pangle_edit.text() == ""
+    assert experiment_widget.Pangle_edit.styleSheet() == INVALID_QLINEEDIT
+
+
+def test_switch_to_powder_s2(hyspec_app, qtbot):
+    """Test switch to Powder check S2 value"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    experiment_widget = hyspec_view.EW
+
+    # set Ei invalid value
+    qtbot.keyClicks(experiment_widget.S2_edit, "6")
+    assert experiment_widget.S2_edit.text() == "306"
+    assert experiment_widget.S2_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # switch to powder
+    hyspec_view.switch_to_powder()
+
+    # Ei value should be the same
+    assert experiment_widget.S2_edit.text() == "306"
+    assert experiment_widget.S2_edit.styleSheet() == INVALID_QLINEEDIT
+
+
+def test_switch_to_powder_deltae_default_value(hyspec_app, qtbot):
+    """Test switch to Powder check DeltaE value"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    crosshair_widget = hyspec_view.CW
+
+    # empty DeltaE value
+    crosshair_widget.DeltaE_edit.clear()
+    assert crosshair_widget.DeltaE_edit.text() == ""
+    assert crosshair_widget.DeltaE_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # switch to powder
+    hyspec_view.switch_to_powder()
+
+    # Delta E value should be back to its default value
+    assert crosshair_widget.DeltaE_edit.text() == "0"
+    assert crosshair_widget.DeltaE_edit.styleSheet() != INVALID_QLINEEDIT
+
+
+def test_switch_to_powder_qmod_default_value(hyspec_app, qtbot):
+    """Test switch to Powder check Qmod value"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    crosshair_widget = hyspec_view.CW
+
+    # empty Qmod value
+    crosshair_widget.modQ_edit.clear()
+    assert crosshair_widget.modQ_edit.text() == ""
+    assert crosshair_widget.modQ_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # switch to powder
+    hyspec_view.switch_to_powder()
+
+    # Qmod value should be back to its default value
+    assert crosshair_widget.modQ_edit.text() == "0"
+    assert crosshair_widget.modQ_edit.styleSheet() != INVALID_QLINEEDIT
+
+
+def test_switch_to_powder_deltae_updated_values(hyspec_app, qtbot):
+    """Test switch to Powder check DeltaE value with a new value"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    crosshair_widget = hyspec_view.CW
+
+    # set a valid DeltaE value
+    crosshair_widget.DeltaE_edit.clear()
+
+    qtbot.keyClicks(crosshair_widget.DeltaE_edit, "4.1")
+    assert crosshair_widget.DeltaE_edit.text() == "4.1"
+
+    # Simulate gaining/losing focus
+    crosshair_widget.DeltaE_edit.setFocus()
+    qtbot.keyPress(crosshair_widget.DeltaE_edit, Qt.Key_Return)
+
+    # empty DeltaE value
+    crosshair_widget.DeltaE_edit.clear()
+    assert crosshair_widget.DeltaE_edit.text() == ""
+    assert crosshair_widget.DeltaE_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # switch to powder
+    hyspec_view.switch_to_powder()
+
+    # Delta E value should be back to its default value
+    assert crosshair_widget.DeltaE_edit.text() == "4.1"
+    assert crosshair_widget.DeltaE_edit.styleSheet() != INVALID_QLINEEDIT
+
+
+def test_switch_to_powder_qmod_updated_values(hyspec_app, qtbot):
+    """Test switch to Powder check Qmod value with a new value"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    crosshair_widget = hyspec_view.CW
+
+    # set a valid Qmod value
+    crosshair_widget.modQ_edit.clear()
+
+    qtbot.keyClicks(crosshair_widget.modQ_edit, "2.35")
+    assert crosshair_widget.modQ_edit.text() == "2.35"
+
+    # Simulate gaining/losing focus
+    crosshair_widget.modQ_edit.setFocus()
+    qtbot.keyPress(crosshair_widget.modQ_edit, Qt.Key_Return)
+
+    # empty DeltaE value
+    crosshair_widget.modQ_edit.clear()
+    assert crosshair_widget.modQ_edit.text() == ""
+    assert crosshair_widget.modQ_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # switch to powder
+    hyspec_view.switch_to_powder()
+
+    # Qmod value should be back to its default value
+    assert crosshair_widget.modQ_edit.text() == "2.35"
+    assert crosshair_widget.modQ_edit.styleSheet() != INVALID_QLINEEDIT

--- a/tests/hppt_presenter/test_presenter.py
+++ b/tests/hppt_presenter/test_presenter.py
@@ -78,9 +78,9 @@ def test_switch_to_powder_ei(hyspec_app, qtbot):
     # switch to powder
     hyspec_view.switch_to_powder()
 
-    # Ei value should be the same
-    assert experiment_widget.Ei_edit.text() == "204"
-    assert experiment_widget.Ei_edit.styleSheet() == INVALID_QLINEEDIT
+    # Ei value should have the default valid value
+    assert experiment_widget.Ei_edit.text() == "20"
+    assert experiment_widget.Ei_edit.styleSheet() != INVALID_QLINEEDIT
 
 
 def test_switch_to_powder_pangle(hyspec_app, qtbot):
@@ -101,9 +101,9 @@ def test_switch_to_powder_pangle(hyspec_app, qtbot):
     # switch to powder
     hyspec_view.switch_to_powder()
 
-    # P angle value should be the same
-    assert experiment_widget.Pangle_edit.text() == ""
-    assert experiment_widget.Pangle_edit.styleSheet() == INVALID_QLINEEDIT
+    # P angle value should have the default valid value
+    assert experiment_widget.Pangle_edit.text() == "0"
+    assert experiment_widget.Pangle_edit.styleSheet() != INVALID_QLINEEDIT
 
 
 def test_switch_to_powder_s2(hyspec_app, qtbot):
@@ -124,9 +124,9 @@ def test_switch_to_powder_s2(hyspec_app, qtbot):
     # switch to powder
     hyspec_view.switch_to_powder()
 
-    # Ei value should be the same
-    assert experiment_widget.S2_edit.text() == "306"
-    assert experiment_widget.S2_edit.styleSheet() == INVALID_QLINEEDIT
+    # Ei value should have the default valid value
+    assert experiment_widget.S2_edit.text() == "30"
+    assert experiment_widget.S2_edit.styleSheet() != INVALID_QLINEEDIT
 
 
 def test_switch_to_powder_deltae_default_value(hyspec_app, qtbot):

--- a/tests/hppt_view/test_basegui.py
+++ b/tests/hppt_view/test_basegui.py
@@ -86,19 +86,3 @@ def test_Selector_widget(qtbot):
 
     assert SELWidget.powder_rb.text() == "Po&wder"
     assert SELWidget.sc_rb.text() == "Single C&rystal"
-
-
-def test_switch_to_SC():
-    """Test switch_to_SC() set SingleCrystalWidget visible"""
-    view = hppt_view.HyspecPPTView()
-    view.switch_to_SC()
-    assert view.SCW.isVisibleTo(view)
-    assert not view.CW.modQ_edit.isEnabled()
-
-
-def test_switch_to_Powder():
-    """Test switch_to_Powder() set SingleCrystalWidget visible"""
-    view = hppt_view.HyspecPPTView()
-    view.switch_to_Powder()
-    assert not view.SCW.isVisibleTo(view)
-    assert view.CW.modQ_edit.isEnabled()

--- a/tests/hppt_view/test_basegui.py
+++ b/tests/hppt_view/test_basegui.py
@@ -88,6 +88,15 @@ def test_Selector_widget(qtbot):
     assert SELWidget.sc_rb.text() == "Single C&rystal"
 
 
+def test_Selector_widget_powder_mode():
+    """Test the Powder Mode in Selector widget when the radio button is pressed"""
+    view = hppt_view.HyspecPPTView()
+    view.SelW.powder_rb.setChecked(True)
+
+    assert not view.SCW.isVisibleTo(view)
+    assert view.CW.modQ_edit.isEnabled()
+
+
 def test_switch_to_SC():
     """Test switch_to_SC() set SingleCrystalWidget visible"""
     view = hppt_view.HyspecPPTView()

--- a/tests/hppt_view/test_basegui.py
+++ b/tests/hppt_view/test_basegui.py
@@ -88,15 +88,6 @@ def test_Selector_widget(qtbot):
     assert SELWidget.sc_rb.text() == "Single C&rystal"
 
 
-def test_Selector_widget_powder_mode():
-    """Test the Powder Mode in Selector widget when the radio button is pressed"""
-    view = hppt_view.HyspecPPTView()
-    view.SelW.powder_rb.setChecked(True)
-
-    assert not view.SCW.isVisibleTo(view)
-    assert view.CW.modQ_edit.isEnabled()
-
-
 def test_switch_to_SC():
     """Test switch_to_SC() set SingleCrystalWidget visible"""
     view = hppt_view.HyspecPPTView()

--- a/tests/hppt_view/test_setdefaults.py
+++ b/tests/hppt_view/test_setdefaults.py
@@ -50,7 +50,8 @@ def test_set_Selector_widget_Default_Values(qtbot):
     """Test the default SC mode is toggled"""
     SelWidget = hppt_view.SelectorWidget()
     qtbot.addWidget(SelWidget)
-    SelWidget.selector_init()
+    label = "Single C&rystal"
+    SelWidget.selector_init(label)
 
     assert SelWidget.sc_rb.isChecked()
     assert not SelWidget.powder_rb.isChecked()

--- a/tests/hppt_view/test_setdefaults.py
+++ b/tests/hppt_view/test_setdefaults.py
@@ -49,7 +49,6 @@ def test_set_Crosshair_widget_Default_Values(qtbot):
 def test_set_Selector_widget_Default_Values(qtbot):
     """Test the default SC mode is toggled"""
     SelWidget = hppt_view.SelectorWidget()
-    SelWidget.set_SC_toggle(True)
     qtbot.addWidget(SelWidget)
 
     assert SelWidget.sc_rb.isChecked()

--- a/tests/hppt_view/test_setdefaults.py
+++ b/tests/hppt_view/test_setdefaults.py
@@ -50,6 +50,7 @@ def test_set_Selector_widget_Default_Values(qtbot):
     """Test the default SC mode is toggled"""
     SelWidget = hppt_view.SelectorWidget()
     qtbot.addWidget(SelWidget)
+    SelWidget.selector_init()
 
     assert SelWidget.sc_rb.isChecked()
     assert not SelWidget.powder_rb.isChecked()

--- a/tests/hppt_view/test_validators.py
+++ b/tests/hppt_view/test_validators.py
@@ -44,7 +44,9 @@ def test_Experiment_validators(qtbot):
     # all valid
     qtbot.keyClicks(ExpWidget.S2_edit, "0")
     ExpWidget.S2_edit.editingFinished.emit()
-    mock_slot.assert_called_once_with({"Ei": 30.0, "S2": -40.0, "alpha_p": -45.0, "plot_type": PLOT_TYPES[0]})
+    mock_slot.assert_called_once_with(
+        {"data": {"Ei": 30.0, "S2": -40.0, "alpha_p": -45.0, "plot_type": PLOT_TYPES[0]}, "name": "experiment"}
+    )
 
 
 def test_Single_Crystal_validators(qtbot):
@@ -91,15 +93,18 @@ def test_Single_Crystal_validators(qtbot):
     SCWidget.a_edit.editingFinished.emit()
     mock_slot.assert_called_once_with(
         {
-            "a": 45.0,
-            "alpha": 45.0,
-            "b": 45.0,
-            "beta": 45.0,
-            "c": 45.0,
-            "gamma": 45.0,
-            "h": -45.0,
-            "k": -45.0,
-            "l": -45.0,
+            "data": {
+                "a": 45.0,
+                "alpha": 45.0,
+                "b": 45.0,
+                "beta": 45.0,
+                "c": 45.0,
+                "gamma": 45.0,
+                "h": -45.0,
+                "k": -45.0,
+                "l": -45.0,
+            },
+            "name": "sc_lattice",
         }
     )
 
@@ -129,4 +134,4 @@ def test_Crosshairs_validators(qtbot):
     # all valid
     qtbot.keyClicks(CHWidget.modQ_edit, "\b")
     CHWidget.DeltaE_edit.editingFinished.emit()
-    mock_slot.assert_called_once_with({"DeltaE": -1.0, "modQ": 2.0})
+    mock_slot.assert_called_once_with({"data": {"DeltaE": -1.0, "modQ": 2.0}, "name": "crosshair"})


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
The code contains mostly changes in the view and presenters parts  for switching from Single Crystal to Powder mode. Other improvements, code cleanup, restructures are included, too. 

# Long description of the changes:
More specifically:
-  Model-View-Presenter connections, variable, updates
-  Crosshair (Qmod and DeltaE) and experiment data (Ei, S2, alpha_p and plot_type) valid values kept and updated during mode switches (From Single Crystal to Powder tested)
- default mode setting and default values initialization
- custom validators separation and simplification
- tests addition and updates
-  other code cleanup and restructure 

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
[Switch from SC to PD Mode](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8619)