### PR TITLE
From Powder to Single Crystal Mode Switch

### DIFF
--- a/src/hyspecppt/hppt/experiment_settings.py
+++ b/src/hyspecppt/hppt/experiment_settings.py
@@ -19,9 +19,8 @@ DEFAULT_LATTICE = dict(a=1, b=1, c=1, alpha=90, beta=90, gamma=90, h=0, k=0, l=0
 DEFAULT_EXPERIMENT = dict(Ei=20, S2=30, alpha_p=0, plot_type=PLOT_TYPES[1])
 DEFAULT_CROSSHAIR = dict(DeltaE=0, modQ=0)
 DEFAULT_MODE = dict(current_experiment_type="single_crystal")
-
 # maximum momentum transfer
-MaxQ = 15
+MAX_MODQ = 15
 
 # invalid style
 INVALID_QLINEEDIT = """

--- a/src/hyspecppt/hppt/hppt_model.py
+++ b/src/hyspecppt/hppt/hppt_model.py
@@ -5,11 +5,14 @@ import logging
 import numpy as np
 from scipy.constants import e, hbar, m_n
 
-<<<<<<< HEAD
-from .experiment_settings import DEFAULT_CROSSHAIR, DEFAULT_EXPERIMENT, DEFAULT_LATTICE, DEFAULT_MODE, PLOT_TYPES, MaxQ
-=======
-from .experiment_settings import MAX_MODQ, PLOT_TYPES
->>>>>>> 14bb4ef (qmod boundaries view, model)
+from .experiment_settings import (
+    DEFAULT_CROSSHAIR,
+    DEFAULT_EXPERIMENT,
+    DEFAULT_LATTICE,
+    DEFAULT_MODE,
+    MAX_MODQ,
+    PLOT_TYPES,
+)
 
 logger = logging.getLogger("hyspecppt")
 

--- a/src/hyspecppt/hppt/hppt_model.py
+++ b/src/hyspecppt/hppt/hppt_model.py
@@ -5,7 +5,11 @@ import logging
 import numpy as np
 from scipy.constants import e, hbar, m_n
 
+<<<<<<< HEAD
 from .experiment_settings import DEFAULT_CROSSHAIR, DEFAULT_EXPERIMENT, DEFAULT_LATTICE, DEFAULT_MODE, PLOT_TYPES, MaxQ
+=======
+from .experiment_settings import MAX_MODQ, PLOT_TYPES
+>>>>>>> 14bb4ef (qmod boundaries view, model)
 
 logger = logging.getLogger("hyspecppt")
 
@@ -119,11 +123,11 @@ class CrosshairParameters:
         """Get the crosshair"""
         if self.current_experiment_type == "single_crystal":
             modQ = self.sc_parameters.calculate_modQ()
-            if modQ < MaxQ:
+            # update the valid value
+            if modQ < MAX_MODQ:
                 self.modQ = modQ
             return dict(DeltaE=self.DeltaE, modQ=modQ)
-        else:
-            return dict(DeltaE=self.DeltaE, modQ=self.modQ)
+        return dict(DeltaE=self.DeltaE, modQ=self.modQ)
 
 
 class HyspecPPTModel:

--- a/src/hyspecppt/hppt/hppt_presenter.py
+++ b/src/hyspecppt/hppt/hppt_presenter.py
@@ -28,6 +28,7 @@ class HyspecPPTPresenter:
         # model init
         # to be removed needs to happen in the model
         self.model.set_experiment_data(**DEFAULT_EXPERIMENT)
+        print("DEFAULT_CROSSHAIR", DEFAULT_CROSSHAIR, DEFAULT_MODE)
         self.model.set_crosshair_data(**DEFAULT_CROSSHAIR, **DEFAULT_MODE)
         self.model.set_single_crystal_data(params=DEFAULT_LATTICE)
 
@@ -94,6 +95,7 @@ class HyspecPPTPresenter:
         # get the valid values for crosshair saved fields
         # if the view contains an invalid value it is overwritten
         saved_values = self.model.get_crosshair_data()
+        print("sc saved", saved_values)
         self.view.CW.set_values(saved_values)
 
         # get the valid values for lattice saved fields

--- a/src/hyspecppt/hppt/hppt_presenter.py
+++ b/src/hyspecppt/hppt/hppt_presenter.py
@@ -66,6 +66,11 @@ class HyspecPPTPresenter:
             )
         else:
             self.model.set_single_crystal_data(data)
+            # update newly calculated qmod
+            # get the valid values for crosshair saved fields
+            # if the view contains an invalid value it is overwritten
+            saved_values = self.model.get_crosshair_data()
+            self.view.CW.set_values(saved_values)
 
     def handle_switch_to_powder(self):
         """Switch to Powder mode"""
@@ -96,6 +101,12 @@ class HyspecPPTPresenter:
         saved_values = self.model.get_crosshair_data()
         self.view.CW.set_values(saved_values)
 
-        # get the valid values for lattice saved fields
-        # saved_values = self.model.get_single_crystal_data()
-        # self.view.CW.set_values(saved_values)
+        # get the valid values for experiment saved fields
+        # if the view contains an invalid value it is overwritten
+        saved_values = self.model.get_experiment_data()
+        self.view.EW.set_values(saved_values)
+
+        # get the valid values for single crystal saved fields
+        # if the view contains an invalid value it is overwritten
+        saved_values = self.model.get_single_crystal_data()
+        self.view.SCW.set_values(saved_values)

--- a/src/hyspecppt/hppt/hppt_presenter.py
+++ b/src/hyspecppt/hppt/hppt_presenter.py
@@ -28,7 +28,6 @@ class HyspecPPTPresenter:
         # model init
         # to be removed needs to happen in the model
         self.model.set_experiment_data(**DEFAULT_EXPERIMENT)
-        print("DEFAULT_CROSSHAIR", DEFAULT_CROSSHAIR, DEFAULT_MODE)
         self.model.set_crosshair_data(**DEFAULT_CROSSHAIR, **DEFAULT_MODE)
         self.model.set_single_crystal_data(params=DEFAULT_LATTICE)
 
@@ -95,7 +94,6 @@ class HyspecPPTPresenter:
         # get the valid values for crosshair saved fields
         # if the view contains an invalid value it is overwritten
         saved_values = self.model.get_crosshair_data()
-        print("sc saved", saved_values)
         self.view.CW.set_values(saved_values)
 
         # get the valid values for lattice saved fields

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -37,9 +37,11 @@ class HyspecPPTView(QWidget):
 
         """
         super().__init__(parent)
-        # callback functions
+
+        # callback functions defined by the presenter
         self.fields_callback = None
         self.powder_mode_switch_callback = None
+        self.sc_mode_switch_callback = None
 
         # callback functions defined by the presenter
         self.fields_callback = None

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -37,6 +37,8 @@ class HyspecPPTView(QWidget):
 
         """
         super().__init__(parent)
+        # callback functions
+        self.ei_callback = None
 
         # callback functions defined by the presenter
         self.fields_callback = None
@@ -439,9 +441,18 @@ class ExperimentWidget(QWidget):
         out_signal["data"] = dict(plot_type=self.Type_combobox.currentText())
         for k, edit in zip(keys, inputs):
             if edit.hasAcceptableInput():
+<<<<<<< HEAD
                 out_signal["data"][k] = float(edit.text())
         if len(out_signal["data"]) == 4:
+=======
+                out_signal[k] = float(edit.text())
+        if len(out_signal) == 4:
+            # to be removed
+>>>>>>> 9834b19 (ei value update and passed from view-presenter-model through callback functions)
             self.valid_signal.emit(out_signal)
+            # send the values
+            if self.parent():
+                self.parent().values_update(self.Ei_edit.text())
 
     def set_values(self, values: dict[str, Union[float, str]]) -> None:
         """Sets widget display based on the values dictionary

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -90,7 +90,7 @@ class HyspecPPTView(QWidget):
         """Fields update"""
         self.fields_callback(values)
 
-    def switch_to_SC(self) -> None:
+    def switch_to_sc(self) -> None:
         """Switch to Single Crystal mode"""
         if self.sc_mode_switch_callback:
             self.sc_mode_switch_callback()
@@ -180,7 +180,7 @@ class SelectorWidget(QWidget):
             if sender == self.powder_label and self.powder_rb.isChecked():
                 self.parent().switch_to_powder()
             if sender == self.sc_label and self.sc_rb.isChecked():
-                self.parent().switch_to_SC()
+                self.parent().switch_to_sc()
 
     def get_selected_mode_label(self) -> str:
         """Return the label of the selected mode

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -38,7 +38,8 @@ class HyspecPPTView(QWidget):
         """
         super().__init__(parent)
         # callback functions
-        self.ei_callback = None
+        self.fields_callback = None
+        self.powder_mode_switch_callback = None
 
         # callback functions defined by the presenter
         self.fields_callback = None
@@ -441,18 +442,22 @@ class ExperimentWidget(QWidget):
         out_signal["data"] = dict(plot_type=self.Type_combobox.currentText())
         for k, edit in zip(keys, inputs):
             if edit.hasAcceptableInput():
-<<<<<<< HEAD
                 out_signal["data"][k] = float(edit.text())
         if len(out_signal["data"]) == 4:
-=======
-                out_signal[k] = float(edit.text())
-        if len(out_signal) == 4:
-            # to be removed
->>>>>>> 9834b19 (ei value update and passed from view-presenter-model through callback functions)
             self.valid_signal.emit(out_signal)
-            # send the values
-            if self.parent():
-                self.parent().values_update(self.Ei_edit.text())
+
+    def set_values(self, values: dict[str, Union[float, str]]) -> None:
+        """Sets widget display based on the values dictionary
+
+        Args:
+            values (dict): a dictionary that contains
+            Ei, S2, alpha_p, plot_types values
+
+        """
+        self.Ei_edit.setText(str(values["Ei"]))
+        self.S2_edit.setText(str(values["S2"]))
+        self.Pangle_edit.setText(str(values["alpha_p"]))
+        self.Type_combobox.setCurrentIndex(PLOT_TYPES.index(values["plot_type"]))
 
     def set_values(self, values: dict[str, Union[float, str]]) -> None:
         """Sets widget display based on the values dictionary

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -237,19 +237,16 @@ class SingleCrystalWidget(QWidget):
         self.alpha_edit = QLineEdit(self)
         self.alpha_label = QLabel(alpha + ":", self)
         self.alpha_label.setBuddy(self.alpha_edit)
-        # self.alpha_edit.setValidator(self.lattice_angle_validator)
         self.alpha_edit.setObjectName("alpha")
 
         self.beta_edit = QLineEdit(self)
         self.beta_label = QLabel(beta + ":", self)
         self.beta_label.setBuddy(self.beta_edit)
-        # self.beta_edit.setValidator(self.lattice_angle_validator)
         self.beta_edit.setObjectName("beta")
 
         self.gamma_edit = QLineEdit(self)
         self.gamma_label = QLabel(gamma + ":", self)
         self.gamma_label.setBuddy(self.gamma_edit)
-        # self.gamma_edit.setValidator(self.lattice_angle_validator)
         self.gamma_edit.setObjectName("gamma")
 
         self.h_edit = QLineEdit(self)
@@ -480,19 +477,6 @@ class ExperimentWidget(QWidget):
                 out_signal["data"][k] = float(edit.text())
         if len(out_signal["data"]) == 4:
             self.valid_signal.emit(out_signal)
-
-    def set_values(self, values: dict[str, Union[float, str]]) -> None:
-        """Sets widget display based on the values dictionary
-
-        Args:
-            values (dict): a dictionary that contains
-            Ei, S2, alpha_p, plot_types values
-
-        """
-        self.Ei_edit.setText(str(values["Ei"]))
-        self.S2_edit.setText(str(values["S2"]))
-        self.Pangle_edit.setText(str(values["alpha_p"]))
-        self.Type_combobox.setCurrentIndex(PLOT_TYPES.index(values["plot_type"]))
 
     def set_values(self, values: dict[str, Union[float, str]]) -> None:
         """Sets widget display based on the values dictionary

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -104,7 +104,6 @@ class HyspecPPTView(QWidget):
         """Set visibility for Single Crystal mode"""
         self.SCW.setVisible(True)
         self.CW.set_Qmod_enabled(False)
-        print("Visibility trace")
 
     def field_visibility_in_Powder(self) -> None:
         """Set visibility for Powder mode"""

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -104,6 +104,7 @@ class HyspecPPTView(QWidget):
         """Set visibility for Single Crystal mode"""
         self.SCW.setVisible(True)
         self.CW.set_Qmod_enabled(False)
+        print("Visibility trace")
 
     def field_visibility_in_Powder(self) -> None:
         """Set visibility for Powder mode"""

--- a/src/hyspecppt/hppt/hppt_view.py
+++ b/src/hyspecppt/hppt/hppt_view.py
@@ -22,7 +22,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from .experiment_settings import INVALID_QLINEEDIT, PLOT_TYPES, alpha, beta, gamma
+from .experiment_settings import INVALID_QLINEEDIT, MAX_MODQ, PLOT_TYPES, alpha, beta, gamma
 from .hppt_view_validators import AbsValidator
 
 
@@ -508,7 +508,7 @@ class CrosshairWidget(QWidget):
         self.DeltaE_validator = QDoubleValidator(parent=self)
         self.DeltaE_validator.setNotation(QDoubleValidator.StandardNotation)
         self.DeltaE_edit.setValidator(self.DeltaE_validator)
-        self.modQ_validator = QDoubleValidator(bottom=0, top=10, parent=self)
+        self.modQ_validator = QDoubleValidator(bottom=0, top=MAX_MODQ, parent=self)
         self.modQ_validator.setNotation(QDoubleValidator.StandardNotation)
         self.modQ_edit.setValidator(self.modQ_validator)
 

--- a/src/hyspecppt/hppt/hppt_view_validators.py
+++ b/src/hyspecppt/hppt/hppt_view_validators.py
@@ -82,10 +82,26 @@ class AngleValidator(QValidator):
 
         # in case this is valid
         if field_validation_status == QValidator.Acceptable:
-            # check all three angles' values are less than 360 degrees
-            if self.alpha.text() and self.beta.text() and self.gamma.text():
-                angle_sum = float(self.alpha.text()) + float(self.beta.text()) + float(self.gamma.text())
-                if angle_sum > 360:
+            alpha_value = self.alpha.text()
+            beta_value = self.beta.text()
+            gamma_value = self.gamma.text()
+
+            if alpha_value and beta_value and gamma_value:
+                alpha_value = float(alpha_value)
+                beta_value = float(beta_value)
+                gamma_value = float(gamma_value)
+
+                # 1. check all three angles' values are less than 360 degrees
+                angle_sum = alpha_value + beta_value + gamma_value
+                # 2. check if they can form a triangle.
+                alpha_beta_sum = alpha_value + beta_value
+                alpha_gamma_sum = alpha_value + gamma_value
+                beta_gamma_sum = beta_value + gamma_value
+
+                # check the conditions
+                if angle_sum > 360 or (
+                    alpha_beta_sum < gamma_value or alpha_gamma_sum < beta_value or beta_gamma_sum < alpha_value
+                ):
                     return QValidator.Intermediate, field_input, field_pos
                 else:
                     return QValidator.Acceptable, field_input, field_pos

--- a/src/hyspecppt/hppt/hppt_view_validators.py
+++ b/src/hyspecppt/hppt/hppt_view_validators.py
@@ -1,4 +1,5 @@
 import copy
+
 from qtpy.QtCore import QObject
 from qtpy.QtGui import QDoubleValidator, QValidator
 

--- a/src/hyspecppt/hppt/hppt_view_validators.py
+++ b/src/hyspecppt/hppt/hppt_view_validators.py
@@ -1,5 +1,4 @@
 import copy
-
 from qtpy.QtCore import QObject
 from qtpy.QtGui import QDoubleValidator, QValidator
 

--- a/src/hyspecppt/hppt/hppt_view_validators.py
+++ b/src/hyspecppt/hppt/hppt_view_validators.py
@@ -100,7 +100,7 @@ class AngleValidator(QValidator):
 
                 # check the conditions
                 if angle_sum > 360 or (
-                    alpha_beta_sum < gamma_value or alpha_gamma_sum < beta_value or beta_gamma_sum < alpha_value
+                    alpha_beta_sum <= gamma_value or alpha_gamma_sum <= beta_value or beta_gamma_sum <= alpha_value
                 ):
                     return QValidator.Intermediate, field_input, field_pos
                 else:

--- a/src/hyspecppt/hppt/hppt_view_validators.py
+++ b/src/hyspecppt/hppt/hppt_view_validators.py
@@ -39,3 +39,53 @@ class AbsValidator(QDoubleValidator):
         x = super().validate(inp, pos)
         # do not "fix" the input
         return x[0], original_str, original_pos
+
+
+class AngleValidator(QValidator):
+    """Angle  validator"""
+
+    alpha: QObject
+    beta: QObject
+    gamma: QObject
+    individual: QValidator
+
+    def __init__(self, parent: QObject, alpha: QObject, beta: QObject, gamma: QObject, individual: QValidator) -> None:
+        """Constructor for the angle value validator.
+
+        Args:
+            parent (QObject): parent
+            alpha (float): the alpha field
+            beta (float): the beta field
+            gamma (float):the gamma field
+            individual (QValidator): validator for each field
+
+        """
+        self.alpha = alpha
+        self.beta = beta
+        self.gamma = gamma
+        self.individual = individual
+
+        super().__init__(parent=parent)
+
+    def validate(self, input_text: str, pos: int) -> tuple[QValidator.State, str, int]:
+        """Override for validate method
+
+        Args:
+            input_text (str): the input string
+            pos (int): cursor position
+
+        """
+        # check the individual field value first
+        field_validation = self.individual.validate(input_text, pos)
+        field_validation_status, field_input, field_pos = field_validation
+
+        # in case this is valid
+        if field_validation_status == QValidator.Acceptable:
+            # check all three angles' values are less than 360 degrees
+            if self.alpha.text() and self.beta.text() and self.gamma.text():
+                angle_sum = float(self.alpha.text()) + float(self.beta.text()) + float(self.gamma.text())
+                if angle_sum > 360:
+                    return QValidator.Intermediate, field_input, field_pos
+                else:
+                    return QValidator.Acceptable, field_input, field_pos
+        return field_validation

--- a/tests/hppt_presenter/test_presenter.py
+++ b/tests/hppt_presenter/test_presenter.py
@@ -171,7 +171,7 @@ def test_switch_to_powder_qmod_default_value(hyspec_app, qtbot):
     hyspec_view.switch_to_powder()
 
     # Qmod value should be back to its default value
-    assert crosshair_widget.modQ_edit.text() == "0.0"
+    assert crosshair_widget.modQ_edit.text() == "0.000"
     assert crosshair_widget.modQ_edit.styleSheet() != INVALID_QLINEEDIT
 
 
@@ -218,7 +218,7 @@ def test_switch_to_powder_qmod_updated_values(hyspec_app, qtbot):
     hyspec_view = hyspec_app.main_window.HPPT_view
     crosshair_widget = hyspec_view.CW
 
-    assert crosshair_widget.modQ_edit.text() == "0.0"
+    assert crosshair_widget.modQ_edit.text() == "0.000"
 
     # switch to powder
     hyspec_view.switch_to_powder()
@@ -243,5 +243,5 @@ def test_switch_to_powder_qmod_updated_values(hyspec_app, qtbot):
     hyspec_view.switch_to_SC()
 
     # Qmod value should be back to its default value
-    assert crosshair_widget.modQ_edit.text() == "0.0"
+    assert crosshair_widget.modQ_edit.text() == "0.000"
     assert crosshair_widget.modQ_edit.styleSheet() != INVALID_QLINEEDIT

--- a/tests/hppt_presenter/test_presenter.py
+++ b/tests/hppt_presenter/test_presenter.py
@@ -245,3 +245,146 @@ def test_switch_to_powder_qmod_updated_values(hyspec_app, qtbot):
     # Qmod value should be back to its default value
     assert crosshair_widget.modQ_edit.text() == "0.000"
     assert crosshair_widget.modQ_edit.styleSheet() != INVALID_QLINEEDIT
+
+
+def test_handle_field_values_update(hyspec_app, qtbot):
+    """Test switch to Single Crystal check sc parameters"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    experiment_widget = hyspec_view.SCW
+    crosshair_widget = hyspec_view.CW
+
+    # switch to single crystal
+    hyspec_view.switch_to_SC()
+
+    # set a valid a h value
+    experiment_widget.h_edit.clear()
+    qtbot.keyClicks(experiment_widget.h_edit, "1")
+    assert experiment_widget.h_edit.text() == "1"
+
+    # set a valid a k value
+    experiment_widget.k_edit.clear()
+    qtbot.keyClicks(experiment_widget.k_edit, "2")
+    assert experiment_widget.k_edit.text() == "2"
+
+    # Simulate gaining/losing focus
+    experiment_widget.k_edit.setFocus()
+    qtbot.keyPress(experiment_widget.k_edit, Qt.Key_Return)
+
+    # Qmod value should be updated with the new value
+    assert crosshair_widget.modQ_edit.text() == "14.050"
+    assert crosshair_widget.modQ_edit.styleSheet() != INVALID_QLINEEDIT
+
+
+def test_switch_to_sc_invalid_updated_default(hyspec_app, qtbot):
+    """Test switch to Single Crystal - check sc parameters default values when switching to powder and back"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    experiment_widget = hyspec_view.SCW
+    crosshair_widget = hyspec_view.CW
+
+    # switch to single crystal
+    hyspec_view.switch_to_SC()
+
+    # set an invalid alpha value
+    qtbot.keyClicks(experiment_widget.alpha_edit, "00")
+    assert experiment_widget.alpha_edit.text() == "900"
+    assert experiment_widget.alpha_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # set an invalid H value
+    experiment_widget.h_edit.clear()
+    assert experiment_widget.h_edit.text() == ""
+    assert experiment_widget.h_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # switch to powder
+    hyspec_view.switch_to_powder()
+
+    # qmod has default value
+    assert crosshair_widget.modQ_edit.text() == "0.000"
+
+    # switch to single crystal
+    hyspec_view.switch_to_SC()
+
+    # single crystals fields back to default values
+    assert experiment_widget.alpha_edit.text() == "90"
+    assert experiment_widget.alpha_edit.styleSheet() != INVALID_QLINEEDIT
+
+    assert experiment_widget.h_edit.text() == "0"
+    assert experiment_widget.h_edit.styleSheet() != INVALID_QLINEEDIT
+
+    # qmod has default value
+    assert crosshair_widget.modQ_edit.text() == "0.000"
+
+
+def test_switch_to_sc_invalid_updated_new(hyspec_app, qtbot):
+    """Test switch to Single Crystal - check sc parameters and qmod new values when switching to powder and back"""
+    # show the app
+    hyspec_app.show()
+    qtbot.waitUntil(hyspec_app.show, timeout=5000)
+    assert hyspec_app.isVisible()
+
+    hyspec_view = hyspec_app.main_window.HPPT_view
+    experiment_widget = hyspec_view.SCW
+    crosshair_widget = hyspec_view.CW
+
+    # switch to single crystal
+    hyspec_view.switch_to_SC()
+
+    # set a valid a k value
+    experiment_widget.h_edit.clear()
+    qtbot.keyClicks(experiment_widget.h_edit, "2.2")
+    assert experiment_widget.h_edit.text() == "2.2"
+
+    # Simulate gaining/losing focus
+    experiment_widget.h_edit.setFocus()
+    qtbot.keyPress(experiment_widget.h_edit, Qt.Key_Return)
+
+    # set an invalid alpha value
+    qtbot.keyClicks(experiment_widget.alpha_edit, "00")
+    assert experiment_widget.alpha_edit.text() == "900"
+    assert experiment_widget.alpha_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # Simulate gaining/losing focus
+    experiment_widget.alpha_edit.setFocus()
+    qtbot.keyPress(experiment_widget.alpha_edit, Qt.Key_Return)
+
+    # set an invalid H value
+    experiment_widget.h_edit.clear()
+    assert experiment_widget.h_edit.text() == ""
+    assert experiment_widget.h_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # Simulate gaining/losing focus
+    experiment_widget.h_edit.setFocus()
+    qtbot.keyPress(experiment_widget.h_edit, Qt.Key_Return)
+
+    # switch to powder
+    hyspec_view.switch_to_powder()
+
+    # qmod has the calculated value
+    assert crosshair_widget.modQ_edit.text() == "13.823"
+    # qmod value updated manually
+    crosshair_widget.modQ_edit.clear()
+    qtbot.keyClicks(crosshair_widget.modQ_edit, "5")
+    assert crosshair_widget.modQ_edit.text() == "5"
+
+    # switch to single crystal
+    hyspec_view.switch_to_SC()
+
+    # single crystals fields back to default values
+    assert experiment_widget.alpha_edit.text() == "90.0"
+    assert experiment_widget.alpha_edit.styleSheet() != INVALID_QLINEEDIT
+
+    # single crystals fields back to the last valid value
+    assert experiment_widget.h_edit.text() == "2.2"
+    assert experiment_widget.h_edit.styleSheet() != INVALID_QLINEEDIT
+
+    # qmod has the calculated value
+    assert crosshair_widget.modQ_edit.text() == "13.823"

--- a/tests/hppt_presenter/test_presenter.py
+++ b/tests/hppt_presenter/test_presenter.py
@@ -34,14 +34,14 @@ def test_selector_widget_powder_mode(hyspec_app, qtbot):
 
 
 def test_switch_to_sc(hyspec_app, qtbot):
-    """Test switch_to_SC() set SingleCrystalWidget visible"""
+    """Test switch_to_sc() set SingleCrystalWidget visible"""
     # show the app
     hyspec_app.show()
     qtbot.waitUntil(hyspec_app.show, timeout=5000)
     assert hyspec_app.isVisible()
 
     hyspec_view = hyspec_app.main_window.HPPT_view
-    hyspec_view.switch_to_SC()
+    hyspec_view.switch_to_sc()
     assert hyspec_view.SCW.isVisibleTo(hyspec_view)
     assert not hyspec_view.CW.modQ_edit.isEnabled()
 
@@ -240,7 +240,7 @@ def test_switch_to_powder_qmod_updated_values(hyspec_app, qtbot):
     assert crosshair_widget.modQ_edit.styleSheet() == INVALID_QLINEEDIT
 
     # switch to powder
-    hyspec_view.switch_to_SC()
+    hyspec_view.switch_to_sc()
 
     # Qmod value should be back to its default value
     assert crosshair_widget.modQ_edit.text() == "0.000"
@@ -259,7 +259,7 @@ def test_handle_field_values_update(hyspec_app, qtbot):
     crosshair_widget = hyspec_view.CW
 
     # switch to single crystal
-    hyspec_view.switch_to_SC()
+    hyspec_view.switch_to_sc()
 
     # set a valid a h value
     experiment_widget.h_edit.clear()
@@ -292,7 +292,7 @@ def test_switch_to_sc_invalid_updated_default(hyspec_app, qtbot):
     crosshair_widget = hyspec_view.CW
 
     # switch to single crystal
-    hyspec_view.switch_to_SC()
+    hyspec_view.switch_to_sc()
 
     # set an invalid alpha value
     qtbot.keyClicks(experiment_widget.alpha_edit, "00")
@@ -311,7 +311,7 @@ def test_switch_to_sc_invalid_updated_default(hyspec_app, qtbot):
     assert crosshair_widget.modQ_edit.text() == "0.000"
 
     # switch to single crystal
-    hyspec_view.switch_to_SC()
+    hyspec_view.switch_to_sc()
 
     # single crystals fields back to default values
     assert experiment_widget.alpha_edit.text() == "90"
@@ -336,7 +336,7 @@ def test_switch_to_sc_invalid_updated_new(hyspec_app, qtbot):
     crosshair_widget = hyspec_view.CW
 
     # switch to single crystal
-    hyspec_view.switch_to_SC()
+    hyspec_view.switch_to_sc()
 
     # set a valid a k value
     experiment_widget.h_edit.clear()
@@ -376,7 +376,7 @@ def test_switch_to_sc_invalid_updated_new(hyspec_app, qtbot):
     assert crosshair_widget.modQ_edit.text() == "5"
 
     # switch to single crystal
-    hyspec_view.switch_to_SC()
+    hyspec_view.switch_to_sc()
 
     # single crystals fields back to default values
     assert experiment_widget.alpha_edit.text() == "90.0"

--- a/tests/hppt_view/test_setdefaults.py
+++ b/tests/hppt_view/test_setdefaults.py
@@ -43,7 +43,7 @@ def test_set_Crosshair_widget_Default_Values(qtbot):
 
     assert CHWidget.DeltaE_edit.text() == "0"
 
-    assert CHWidget.modQ_edit.text() == "0"
+    assert CHWidget.modQ_edit.text() == "0.000"
 
 
 def test_set_Selector_widget_Default_Values(qtbot):

--- a/tests/hppt_view/test_validators.py
+++ b/tests/hppt_view/test_validators.py
@@ -135,3 +135,76 @@ def test_Crosshairs_validators(qtbot):
     qtbot.keyClicks(CHWidget.modQ_edit, "\b")
     CHWidget.DeltaE_edit.editingFinished.emit()
     mock_slot.assert_called_once_with({"data": {"DeltaE": -1.0, "modQ": 2.0}, "name": "crosshair"})
+
+
+def test_sc_validator_sum_angles_condition(qtbot):
+    """Test validators for the single crystal widget: total sum > 260"""
+    sc_widget = hppt_view.SingleCrystalWidget()
+    qtbot.addWidget(sc_widget)
+
+    # alpha
+    sc_widget.alpha_edit.clear()
+    qtbot.keyClicks(sc_widget.alpha_edit, "120")
+    assert sc_widget.alpha_edit.text() == "120"
+    assert sc_widget.alpha_edit.styleSheet() == ""
+
+    # beta
+    sc_widget.beta_edit.clear()
+    qtbot.keyClicks(sc_widget.beta_edit, "120")
+    assert sc_widget.beta_edit.text() == "120"
+    assert sc_widget.beta_edit.styleSheet() == ""
+
+    # gamma
+    sc_widget.gamma_edit.clear()
+    qtbot.keyClicks(sc_widget.gamma_edit, "122")
+    assert sc_widget.gamma_edit.text() == "122"
+
+    # sum = 362
+    assert sc_widget.alpha_edit.styleSheet() == INVALID_QLINEEDIT
+    assert sc_widget.beta_edit.styleSheet() == INVALID_QLINEEDIT
+    assert sc_widget.gamma_edit.styleSheet() == INVALID_QLINEEDIT
+
+
+def test_sc_validator_triangle_condition(qtbot):
+    """Test validators for the single crystal widget: pairs of < third field"""
+    sc_widget = hppt_view.SingleCrystalWidget()
+    qtbot.addWidget(sc_widget)
+
+    # alpha + beta > gamma
+    sc_widget.alpha_edit.clear()
+    sc_widget.beta_edit.clear()
+    sc_widget.gamma_edit.clear()
+
+    qtbot.keyClicks(sc_widget.alpha_edit, "40")
+    qtbot.keyClicks(sc_widget.beta_edit, "40")
+    qtbot.keyClicks(sc_widget.gamma_edit, "100")
+
+    assert sc_widget.alpha_edit.styleSheet() == INVALID_QLINEEDIT
+    assert sc_widget.beta_edit.styleSheet() == INVALID_QLINEEDIT
+    assert sc_widget.gamma_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # alpha + gamma > beta
+    sc_widget.alpha_edit.clear()
+    sc_widget.beta_edit.clear()
+    sc_widget.gamma_edit.clear()
+
+    qtbot.keyClicks(sc_widget.alpha_edit, "40")
+    qtbot.keyClicks(sc_widget.beta_edit, "110")
+    qtbot.keyClicks(sc_widget.gamma_edit, "50")
+
+    assert sc_widget.alpha_edit.styleSheet() == INVALID_QLINEEDIT
+    assert sc_widget.beta_edit.styleSheet() == INVALID_QLINEEDIT
+    assert sc_widget.gamma_edit.styleSheet() == INVALID_QLINEEDIT
+
+    # beta + gamma > alpha
+    sc_widget.alpha_edit.clear()
+    sc_widget.beta_edit.clear()
+    sc_widget.gamma_edit.clear()
+
+    qtbot.keyClicks(sc_widget.alpha_edit, "92")
+    qtbot.keyClicks(sc_widget.beta_edit, "40")
+    qtbot.keyClicks(sc_widget.gamma_edit, "45")
+
+    assert sc_widget.alpha_edit.styleSheet() == INVALID_QLINEEDIT
+    assert sc_widget.beta_edit.styleSheet() == INVALID_QLINEEDIT
+    assert sc_widget.gamma_edit.styleSheet() == INVALID_QLINEEDIT


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
The code includes mainly changes for switching from powder mode to Single crystal. This is the second part of the switch, so any multiple switching back and forth are captured here and the related tests.

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->
It includes the following:
- view and presenter changes for single crystal parameters and qmod values
- custom validators for single crystal angle fields
-  tests for mode switching, and validators
- code cleanup, improvements to conform with variable naming standards
-  mode get_crosshair small updates

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
[Switch from PD and SC mode](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8624)
